### PR TITLE
New home for sceptre-date-resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,9 @@ Categories: Added, Removed, Changed, Fixed, Nonfunctional, Deprecated
 
 <!--- All unreleased items go here  -->
 
-<!--- Example CHANGELOG entry
-
-## 0.1.0 (2019.07.02)
+## 1.0.0 (2019.09.27)
 
 ### Added
 
 - Initial resolver code
 
--->

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ coverage: coverage-all
 		coverage report --show-missing
 
 test:
-	    python -m pytest --junitxml=test-reports/junit.xml
+	    pytest --junitxml=test-reports/junit.xml
 
 lint:
 	    flake8 .

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ coverage: coverage-all
 		coverage report --show-missing
 
 test:
-	    pytest --junitxml=test-reports/junit.xml
+	    python -m pytest --junitxml=test-reports/junit.xml
 
 lint:
 	    flake8 .

--- a/README.md
+++ b/README.md
@@ -1,14 +1,45 @@
-# README
+---
+layout: docs
+title: Resolvers
+---
 
-Add your resolver readme here. Remember to include the following:
+# Overview
 
-- Tell people how to install it (e.g. pip install ...).
-- Be clear about the purpose of the resolver, its capabilities and limitations.
-- Tell people how to use it.
-- Give examples of the resolver in use.
+The purpose of this resolver is to retrieve the current datetime
 
-Read our wiki to learn how to use this repo:
-https://github.com/Sceptre/project/wiki/Sceptre-Resolver-Template
+## Available Resolvers
 
-If you have any questions or encounter an issue
-[please open an issue](https://github.com/Sceptre/project/issues/new)
+### date
+
+Fetches the current datetime in an [ISO 8601 format](https://docs.python.org/3/library/time.html#time.strftime).
+The default format is "%Y-%m-%d %H:%M:%S".
+
+Syntax:
+
+```yaml
+parameter|sceptre_user_data:
+    <name>: !date
+```
+
+Examples:
+
+Retrieve date (using default format) and pass it to a
+cloudformation parameter:
+```
+parameters:
+    now: !date
+```
+
+Retrieve the date (in MM/DD/YYYY format) and pass it to a
+cloudformation parameter:
+```
+parameters:
+    now: !date "%m/%d/%Y"
+```
+
+Retrieve the time (in H:M:S format) and pass it to a
+cloudformation parameter:
+```
+parameters:
+    now: !date "%H:%M:%S"
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pytest-runner>=3.0.0,<3.1.0
 pytest>=3.2.0,<3.3.0
 readme-renderer>=24.0
 setuptools>=40.6.2
-git+git://github.com/sceptre/sceptre-core.git@master#egg=sceptre-core
+git+git://github.com/sceptre/sceptre.git@master#egg=sceptre
 tox>=2.9.1,<3.0.0
 twine>=1.12.1
 wheel==0.32.3

--- a/resolver/date.py
+++ b/resolver/date.py
@@ -1,14 +1,49 @@
+# -*- coding: utf-8 -*-
+
+import logging
+import datetime
+
 from sceptre.resolvers import Resolver
 
 
-class DateResolver(Resolver):
+class Date(Resolver):
+    """
+    Resolves the current datetime.
+
+    :param argument: The ISO 8601 date format:
+            https://docs.python.org/3/library/time.html#time.strftime
+    :type argument: str
+    """
+
+    DEFAULT_FORMAT = "%Y-%m-%d %H:%M:%S"
+
     def __init__(self, *args, **kwargs):
-        super(DateResolver, self).__init__(*args, **kwargs)
+        self.logger = logging.getLogger(__name__)
+        super(Date, self).__init__(*args, **kwargs)
 
     def resolve(self):
         """
-        resolve is the method called by Sceptre. It should carry out the work
-        intended by this resolver. It should return a string to become the
-        final value.
+        Retrieves the current date.
+
+        :returns: the current date
+        :rtype: str
         """
-        return self.argument
+        format = self.DEFAULT_FORMAT
+
+        if self.argument:
+            format = self.argument
+
+        try:
+            now = datetime.datetime.now()
+            date = now.strftime(format)
+            self.logger.debug("%s - date: %s",
+                              self.stack.name, date)
+        except ValueError as ve:
+            self.logger.error("%s - Invalid date format: %s",
+                              self.stack.name, format)
+        except Exception as e:
+            self.logger.error("%s - Failed to resolve date",
+                              self.stack.name)
+            raise e
+
+        return date

--- a/resolver/date.py
+++ b/resolver/date.py
@@ -1,9 +1,9 @@
 from sceptre.resolvers import Resolver
 
 
-class CustomResolver(Resolver):
+class DateResolver(Resolver):
     def __init__(self, *args, **kwargs):
-        super(CustomResolver, self).__init__(*args, **kwargs)
+        super(DateResolver, self).__init__(*args, **kwargs)
 
     def resolve(self):
         """

--- a/resolver/date.py
+++ b/resolver/date.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 
+import abc
+import six
 import logging
 from datetime import datetime
 
 from sceptre.resolvers import Resolver
 
 
-class Date(Resolver):
+@six.add_metaclass(abc.ABCMeta)
+class DateResolver(Resolver):
     """
     Resolves the current datetime.
 
@@ -19,7 +22,7 @@ class Date(Resolver):
 
     def __init__(self, *args, **kwargs):
         self.logger = logging.getLogger(__name__)
-        super(Date, self).__init__(*args, **kwargs)
+        super(DateResolver, self).__init__(*args, **kwargs)
 
     def resolve(self):
         """

--- a/resolver/date.py
+++ b/resolver/date.py
@@ -38,8 +38,9 @@ class DateResolver(Resolver):
 
         try:
             now = datetime.now()
-            print("\nit's now: "+str(now))
             date = now.strftime(format)
+            self.logger.debug("%s - date: %s",
+                              self.stack.name, date)
 
         except Exception as e:
             raise e

--- a/resolver/date.py
+++ b/resolver/date.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
-import datetime
+from datetime import datetime
 
 from sceptre.resolvers import Resolver
 
@@ -23,7 +23,7 @@ class Date(Resolver):
 
     def resolve(self):
         """
-        Retrieves the current date.
+        Retrieves the current date in ISO 8601 format
 
         :returns: the current date
         :rtype: str
@@ -34,16 +34,11 @@ class Date(Resolver):
             format = self.argument
 
         try:
-            now = datetime.datetime.now()
+            now = datetime.now()
+            print("\nit's now: "+str(now))
             date = now.strftime(format)
-            self.logger.debug("%s - date: %s",
-                              self.stack.name, date)
-        except ValueError as ve:
-            self.logger.error("%s - Invalid date format: %s",
-                              self.stack.name, format)
+
         except Exception as e:
-            self.logger.error("%s - Failed to resolve date",
-                              self.stack.name)
             raise e
 
         return date

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.2
+current_version = 1.0.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 commit = True
 tag = True

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ RESOLVER_COMMAND_NAME = 'date'
 # do not change. Rename resolver/resolver.py to resolver/{RESOLVER_COMMAND_NAME}.py
 RESOLVER_MODULE_NAME = 'resolver.{}'.format(RESOLVER_COMMAND_NAME)
 # CamelCase name of resolver class in resolver.resolver.
-RESOLVER_CLASS = 'DateResolver'
+RESOLVER_CLASS = 'Date'
 # One line summary description
 RESOLVER_DESCRIPTION = 'A Sceptre resolver to retrieve the current datetime'
 # if multiple use a single string with comma separated names.

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,25 @@
 from setuptools import setup, find_packages
 
-__version__ = "0.0.1"
+__version__ = "1.0.0"
 
 # More information on setting values:
 # https://github.com/Sceptre/project/wiki/sceptre-resolver-template
 
 # lowercase, use `-` as separator.
-RESOLVER_NAME = 'sceptre-resolver-template'
+RESOLVER_NAME = 'sceptre-date-resolver'
 # the resolver call in sceptre e.g. !command_name.
-RESOLVER_COMMAND_NAME = 'custom_resolver'
+RESOLVER_COMMAND_NAME = 'date'
 # do not change. Rename resolver/resolver.py to resolver/{RESOLVER_COMMAND_NAME}.py
 RESOLVER_MODULE_NAME = 'resolver.{}'.format(RESOLVER_COMMAND_NAME)
 # CamelCase name of resolver class in resolver.resolver.
-RESOLVER_CLASS = 'CustomResolver'
+RESOLVER_CLASS = 'DateResolver'
 # One line summary description
-RESOLVER_DESCRIPTION = ''
+RESOLVER_DESCRIPTION = 'A Sceptre resolver to retrieve the current datetime'
 # if multiple use a single string with comma separated names.
-RESOLVER_AUTHOR = 'Sceptre'
+RESOLVER_AUTHOR = 'zaro0508'
 # if multiple use single string with commas.
-RESOLVER_AUTHOR_EMAIL = 'sceptre@cloudreach.com'
-RESOLVER_URL = 'https://github.com/sceptre/{}'.format(RESOLVER_NAME)
+RESOLVER_AUTHOR_EMAIL = 'zaro0508@gmail.com'
+RESOLVER_URL = 'https://github.com/sceptre/sceptre-date-resolver{}'.format(RESOLVER_NAME)
 
 with open("README.md") as readme_file:
     README = readme_file.read()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ RESOLVER_COMMAND_NAME = 'date'
 # do not change. Rename resolver/resolver.py to resolver/{RESOLVER_COMMAND_NAME}.py
 RESOLVER_MODULE_NAME = 'resolver.{}'.format(RESOLVER_COMMAND_NAME)
 # CamelCase name of resolver class in resolver.resolver.
-RESOLVER_CLASS = 'Date'
+RESOLVER_CLASS = 'DateResolver'
 # One line summary description
 RESOLVER_DESCRIPTION = 'A Sceptre resolver to retrieve the current datetime'
 # if multiple use a single string with comma separated names.

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from mock import MagicMock
 from sceptre.stack import Stack
 
+
 class TestDateResolver(object):
 
     def setup_method(self, test_method):

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -1,5 +1,5 @@
 
-class TestStackActions(object):
+class TestDateResolver(object):
     def setup_method(self, test_method):
         pass
 

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 
-import pytest
-
-from resolver.date import Date
+from resolver.date import DateResolver
 from datetime import datetime
+
 
 class TestDateResolver(object):
 
     def setup_method(self, test_method):
-        self.file_contents_resolver = Date(
+        self.file_contents_resolver = DateResolver(
             argument=None
         )
 
@@ -22,10 +21,9 @@ class TestDateResolver(object):
 
     # invalid input will result in date in default format
     def test_resolving_with_invalid_format(self):
+        format = ""
+        expected_date = datetime.now().strftime(format)
+
         self.file_contents_resolver.argument = "invalid"
         result = self.file_contents_resolver.resolve()
-
-    # none input will result in date with default format
-    def test_resolving_with_none_format(self):
-        self.file_contents_resolver.argument = None
-        result = self.file_contents_resolver.resolve()
+        assert result[:10] != expected_date[:10]

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -1,7 +1,31 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from resolver.date import Date
+from datetime import datetime
 
 class TestDateResolver(object):
-    def setup_method(self, test_method):
-        pass
 
-    def test_dummy_test(self):
-        pass
+    def setup_method(self, test_method):
+        self.file_contents_resolver = Date(
+            argument=None
+        )
+
+    def test_resolving_with_valid_format(self):
+        format = "%m/%d/%Y"
+        expected_date = datetime.now().strftime(format)
+
+        self.file_contents_resolver.argument = format
+        result = self.file_contents_resolver.resolve()
+        assert result == expected_date
+
+    # invalid input will result in date in default format
+    def test_resolving_with_invalid_format(self):
+        self.file_contents_resolver.argument = "invalid"
+        result = self.file_contents_resolver.resolve()
+
+    # none input will result in date with default format
+    def test_resolving_with_none_format(self):
+        self.file_contents_resolver.argument = None
+        result = self.file_contents_resolver.resolve()

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -2,21 +2,24 @@
 
 from resolver.date import DateResolver
 from datetime import datetime
-
+from mock import MagicMock
+from sceptre.stack import Stack
 
 class TestDateResolver(object):
 
     def setup_method(self, test_method):
-        self.file_contents_resolver = DateResolver(
-            argument=None
+        stack = MagicMock(spec=Stack)
+        stack.name = "test"
+        self.date_resolver = DateResolver(
+            None, stack
         )
 
     def test_resolving_with_valid_format(self):
         format = "%m/%d/%Y"
         expected_date = datetime.now().strftime(format)
 
-        self.file_contents_resolver.argument = format
-        result = self.file_contents_resolver.resolve()
+        self.date_resolver.argument = format
+        result = self.date_resolver.resolve()
         assert result == expected_date
 
     # invalid input will result in date in default format
@@ -24,6 +27,6 @@ class TestDateResolver(object):
         format = ""
         expected_date = datetime.now().strftime(format)
 
-        self.file_contents_resolver.argument = "invalid"
-        result = self.file_contents_resolver.resolve()
+        self.date_resolver.argument = "invalid"
+        result = self.date_resolver.resolve()
         assert result[:10] != expected_date[:10]


### PR DESCRIPTION
Move the sceptre-date-resolver from https://github.com/zaro0508/sceptre-date-resolver
to the official Sceptre github Org.